### PR TITLE
Remove Dark Sky, Fix OpenWeatherMap API

### DIFF
--- a/src/pkjs/config.json
+++ b/src/pkjs/config.json
@@ -175,10 +175,6 @@
 						"value": "none"
 					},
 					{ 
-						"label": "Dark Sky",
-						"value": "darksky"
-					},
-					{ 
 						"label": "OpenWeather",
 						"value": "owm"
 					},

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -71,25 +71,8 @@ function requestOwm(lat, lon, callback) {
 
 		createRequest(dailyEndpoint, function (responseText) {
 			const json = JSON.parse(responseText);
-			min = json.list[0].main.temp_min;
-			max = json.list[0].main.temp_max;
-
-			for (i = 1; i < json.list.length; i++) {
-				if (json.list[i].main.temp_min < min) {
-					min = json.list[i].main.temp_min;
-				}
-				if (json.list[i].main.temp_max > max) {
-					max = json.list[i].main.temp_max;
-				}
-			}
-
-			if (now < min) {
-				min = now;
-			}
-			if (now > max) {
-				max = now;
-			}
-
+			min = Math.min.apply(null, [now].concat(json.list.map(function (t) { return t.main.temp_min; })));
+			max = Math.max.apply(null, [now].concat(json.list.map(function (t) { return t.main.temp_max; })));
 			callback([now, min, max]);
 		});
 	});

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -57,8 +57,6 @@ function requestOwm(lat, lon, callback) {
 
 	// This endpoint provides the forecast for a 3-hour window. Grab the next 24 hours.
 	const dailyEndpoint = 'https://api.openweathermap.org/data/2.5/forecast?cnt=8&'+query;
-	console.log(nowEndpoint);
-	console.log(dailyEndpoint);
 
 	createRequest(nowEndpoint, function (responseText) {
 		const json = JSON.parse(responseText);

--- a/src/pkjs/index.js
+++ b/src/pkjs/index.js
@@ -50,26 +50,6 @@ function createRequest(url, callback, attempt) {
 	xhr.send();
 };
 
-function requestDarksky(lat, lon, callback) {
-	const units = (tempUnits === 'c') ? 'si' : 'us';
-	const url = 'https://api.darksky.net/forecast/'+weatherAPIKey+'/'+lat+','+lon+'?units='+units+'&exclude=minutely,hourly,alerts,flags';
-
-	createRequest(url, function (responseText) {
-		const json = JSON.parse(responseText);
-		var now, min, max;
-		if (tempFeelsLike) {
-			now = json.currently.apparentTemperature;
-			min = json.daily.data[0].apparentTemperatureLow;
-			max = json.daily.data[0].apparentTemperatureHigh;
-		} else {
-			now = json.currently.temperature;
-			min = json.daily.data[0].temperatureLow;
-			max = json.daily.data[0].temperatureHigh;
-		}
-		callback([now, min, max]);
-	});
-}
-
 function requestOwm(lat, lon, callback) {
 	const units = (tempUnits === 'c') ? 'metric' : 'imperial';
 	const url = 'http://api.openweathermap.org/data/2.5/onecall?lat='+lat+'&lon='+lon+'&units='+units+'&appid='+weatherAPIKey+'&exclude=hourly,minutely,alerts';
@@ -148,9 +128,6 @@ function locationSuccess(pos) {
 		const lon = pos.coords.longitude;
 		var weatherFunction;
 		switch (weatherProvider) {
-			case 'darksky':
-				weatherFunction = requestDarksky;
-				break;
 			case 'owm':
 				weatherFunction = requestOwm;
 				break;


### PR DESCRIPTION
This commit removes the Dark Sky API as it no longer exists. It also updates the OpenWeatherMap API because the [One Call API](https://openweathermap.org/api/one-call-3) was updated to 3.0 and the old 2.5 calls no longer work.

It updates temperature by:
- Retrieving the current conditions using the [Current weather data API](https://openweathermap.org/current).
- And retrieves the daily forecast by using the [5 day / 3 hour forecast API](https://openweathermap.org/forecast5) and finding the min and max. The [daily forecast API](https://openweathermap.org/forecast16) is [not freely available to everybody](https://openweathermap.org/price) and didn't seem like a good fit for this use case.

With these changes, the watchface continues to work without needing to subscribe or provide payment details to OpenWeatherMap.

Thank you for the creation of this watchface! I'm excited for renewed interest in Pebble watches with [the recent news](https://ericmigi.com/blog/why-were-bringing-pebble-back).